### PR TITLE
Serve random coin data from cache with single API route

### DIFF
--- a/src/app/api/random-coin/route.ts
+++ b/src/app/api/random-coin/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from "next/server";
 import { getOrRefreshRandomCoinPayload, type RandomCoinPayload } from "@/lib/randomCoin";
+import { RANDOM_COIN_CHART_DAYS } from "@/lib/cache";
 
-export async function GET() {
+export type RandomCoinResponse = RandomCoinPayload & { imageUrl: string };
+export async function GET(req: Request) {
   try {
     const payload = await getOrRefreshRandomCoinPayload();
     if (!payload) return NextResponse.json({ error: "No payload" }, { status: 500 });
-    const json: RandomCoinPayload = payload;
+    const origin = new URL(req.url).origin;
+    const imageUrl = `${origin}/og?id=${encodeURIComponent(payload.coin.id)}&days=${RANDOM_COIN_CHART_DAYS}`;
+    const json: RandomCoinResponse = { ...payload, imageUrl };
     return NextResponse.json(json);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/src/lib/coingecko.ts
+++ b/src/lib/coingecko.ts
@@ -2,6 +2,9 @@ export type CoinGeckoCoin = {
   id: string;
   symbol: string;
   name: string;
+  image?: string;
+  current_price?: number;
+  market_cap?: number;
 };
 
 const COINGECKO_API_BASE = "https://api.coingecko.com/api/v3";
@@ -51,6 +54,9 @@ type MarketCoin = {
   id: string;
   symbol: string;
   name: string;
+  image?: string;
+  current_price?: number;
+  market_cap?: number;
 };
 
 /**
@@ -86,7 +92,14 @@ export async function fetchCoinsByCategory(
     throw new Error(`CoinGecko markets failed: ${res.status} ${res.statusText} - ${text.slice(0, 200)}`);
   }
   const list = (await res.json()) as MarketCoin[];
-  return list.map((c) => ({ id: c.id, symbol: c.symbol, name: c.name }));
+  return list.map((c) => ({
+    id: c.id,
+    symbol: c.symbol,
+    name: c.name,
+    image: c.image,
+    current_price: c.current_price,
+    market_cap: c.market_cap,
+  }));
 }
 
 // Coin detail subset


### PR DESCRIPTION
## Summary
- Cache random Base meme coin and its price chart in Redis and only call CoinGecko when the cache is empty
- Expose a single `/api/random-coin` endpoint that returns payload with a prebuilt `/og` image URL
- Move the `/og` image route out of `/api` and render charts solely from cached data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897976099a08331919548ab77912f7d